### PR TITLE
fix: small correction output existing groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_management_lock" "lock" {
     for k, v in var.groups : k => v if try(v.management_lock != null, false)
   }
 
-  name = "lock-${each.key}"
+  name = try(each.value.management_lock.name, "lock-${each.key}")
   scope = try(
     (var.use_existing_groups || lookup(each.value, "use_existing_group", false)) ? data.azurerm_resource_group.existing[each.key].id :
     azurerm_resource_group.groups[each.key].id, null

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,6 @@ resource "azurerm_management_lock" "lock" {
     azurerm_resource_group.groups[each.key].id, null
   )
 
-  lock_level = try(each.value.management_lock.level, "cannotdelete")
+  lock_level = try(each.value.management_lock.level, "CanNotDelete")
   notes      = try(each.value.management_lock.notes, null)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,6 @@ output "groups" {
 output "groups_existing" {
   description = "Contains all resource groups considered existing based on global and local flags."
   value = var.use_existing_groups ? var.groups : {
-    for k, v in var.groups : k => v if lookup(v, "use_existing_group", false)
+    for k, v in var.groups : k => v if lookup(v, "use_existing_group", true)
   }
 }


### PR DESCRIPTION
- Changed the output to 'true' as the default value for existing groups
- Changed the default value to CamelCase for 'CanNotDelete' lock. 
- Updated possibility to override the name for the lock. 